### PR TITLE
Potential fix for code scanning alert no. 25: DOM text reinterpreted as HTML

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -1306,11 +1306,13 @@ function decodeHtmlEntities(text) { const t = document.createElement('textarea')
 function escHtml(v) { if (v == null) return ''; return String(v).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;'); }
 function formatMessageContent(text) {
     if (!text) return text;
-    let formatted = text.replace(/```([a-zA-Z0-9+#-]*)\n?([\s\S]*?)```/g, (match, lang, code) => {
+    const safeText = escHtml(String(text));
+    let formatted = safeText.replace(/```([a-zA-Z0-9+#-]*)\n?([\s\S]*?)```/g, (match, lang, code) => {
         code = decodeHtmlEntities(code.trim());
+        const safeLang = escAttr(lang || '');
         let highlighted = '';
         try { if (lang && hljs.getLanguage(lang)) highlighted = hljs.highlight(code, { language: lang }).value; else highlighted = hljs.highlightAuto(code).value; } catch (e) { highlighted = code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'); }
-        return `<div class="code-wrapper"><button class="copy-code-btn" onclick="copyCodeBlock(this, '${encodeURIComponent(code)}')"><span class="material-symbols-outlined" style="font-size:16px;">content_copy</span></button><pre><code class="hljs ${lang}">${highlighted}</code></pre></div>`;
+        return `<div class="code-wrapper"><button class="copy-code-btn" onclick="copyCodeBlock(this, '${encodeURIComponent(code)}')"><span class="material-symbols-outlined" style="font-size:16px;">content_copy</span></button><pre><code class="hljs ${safeLang}">${highlighted}</code></pre></div>`;
     });
     formatted = formatted.replace(/__AEMOJI__([^\/]+)\/\/\/(.+?)__/g, (match, cat, name) => {
         const safeName = name.replace(/"/g, '&quot;');


### PR DESCRIPTION
Potential fix for [https://github.com/SayGGGo/Tornado/security/code-scanning/25](https://github.com/SayGGGo/Tornado/security/code-scanning/25)

To fix this without changing intended functionality, ensure raw message text is HTML-escaped before any markup-oriented replacements in `formatMessageContent`. Then keep the existing formatting pipeline (fenced code blocks, animated emoji tokens, newline-to-`<br>`), but operate on escaped text. For code blocks, decode only the fenced code payload for highlighting, and escape `lang` when inserted into class attributes.

Best single fix in `static/js/chat.js`:
- Edit `formatMessageContent` (around lines 1307–1322).
- Add an initial `escHtml` pass on input text (`const safeText = escHtml(String(text));`).
- Run all regex replacements on `safeText` rather than raw `text`.
- Escape `lang` when embedding in `class="hljs ..."`.

No new imports or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
