### PR TITLE
Potential fix for code scanning alert no. 20: Uncontrolled data used in path expression

### DIFF
--- a/chat/routes.py
+++ b/chat/routes.py
@@ -193,7 +193,10 @@ def register_chat(app):
         safe = os.path.basename(filename)
         if not re.match(r'^[0-9a-f]{32}\.[a-z0-9]{1,10}$', safe):
             abort(400)
-        fpath = os.path.join(FileService.UPLOAD_DIR, safe)
+        upload_root = os.path.realpath(FileService.UPLOAD_DIR)
+        fpath = os.path.realpath(os.path.join(upload_root, safe))
+        if os.path.commonpath([upload_root, fpath]) != upload_root:
+            abort(400)
         if not os.path.isfile(fpath):
             abort(404)
         resp = send_from_directory(FileService.UPLOAD_DIR, safe)


### PR DESCRIPTION
Potential fix for [https://github.com/SayGGGo/Tornado/security/code-scanning/20](https://github.com/SayGGGo/Tornado/security/code-scanning/20)

Use canonical path validation before any filesystem operation with user-influenced names:

- Build the candidate path with `os.path.join`.
- Normalize/canonicalize with `os.path.realpath`.
- Canonicalize the upload root too.
- Enforce containment using `os.path.commonpath([root, candidate]) == root`.
- Abort if containment fails, then continue existing logic.

Best minimal fix in `chat/routes.py` is to update `serve_file` around lines 196–197 so `fpath` is validated against `FileService.UPLOAD_DIR` before `os.path.isfile(fpath)` is called. This preserves behavior while making traversal/path confusion impossible even if upstream checks are later weakened.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
