### PR TITLE
Potential fix for code scanning alert no. 19: Replacement of a substring with itself

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -1889,7 +1889,7 @@ function saveKeybinds() {
     setCookie('keybinds', JSON.stringify(keybinds), 365);
 }
 function formatKey(code) {
-    return code.replace(/^Key/, '').replace(/^Digit/, '').replace(/^Arrow/, '↑↓←→'['UDLR'.indexOf(code.slice(5))]).replace('AltLeft','Alt').replace('AltRight','Alt⊞').replace('ShiftLeft','⇧').replace('ShiftRight','⇧').replace('ControlLeft','Ctrl').replace('ControlRight','Ctrl⊞').replace('Space','Space');
+    return code.replace(/^Key/, '').replace(/^Digit/, '').replace(/^Arrow/, '↑↓←→'['UDLR'.indexOf(code.slice(5))]).replace('AltLeft','Alt').replace('AltRight','Alt⊞').replace('ShiftLeft','⇧').replace('ShiftRight','⇧').replace('ControlLeft','Ctrl').replace('ControlRight','Ctrl⊞');
 }
 document.addEventListener('mousedown', function(e) {
     if (e.button !== 1) return;


### PR DESCRIPTION
Potential fix for [https://github.com/SayGGGo/Tornado/security/code-scanning/19](https://github.com/SayGGGo/Tornado/security/code-scanning/19)

Remove the redundant self-replacement from `formatKey` in `static/js/chat.js`.

- **General fix**: when a `replace` call uses identical source and replacement text, either correct the replacement to the intended transformed value or remove the call if no transformation is needed.
- **Best fix here**: delete `.replace('Space','Space')` from the replacement chain on/around line 1892, since it does nothing and there is no evidence that a different replacement was intended.
- **Scope**: only edit `static/js/chat.js`, in `function formatKey(code)`.
- **No new imports/dependencies** are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
