### PR TITLE
Potential fix for code scanning alert no. 18: Information exposure through an exception

### DIFF
--- a/spotify/routes.py
+++ b/spotify/routes.py
@@ -166,7 +166,8 @@ def register_spotify(app):
             
             return jsonify({"ok": True})
         except Exception as e:
-            return jsonify({"ok": False, "error": str(e)})
+            logger.exception("Spotify control failed for user_id=%s action=%s", user_id, action)
+            return jsonify({"ok": False, "error": "Failed to control Spotify playback"}), 500
 
     @app.route("/api/spotify/toggle", methods=["POST"])
     def spotify_toggle():


### PR DESCRIPTION
Potential fix for [https://github.com/SayGGGo/Tornado/security/code-scanning/18](https://github.com/SayGGGo/Tornado/security/code-scanning/18)

To fix this safely without changing functionality, keep the `try/except` control flow and success response unchanged, but replace the client-facing `str(e)` with a generic message and log the exception internally.

Best change in `spotify/routes.py` (inside `spotify_control`):
- In the `except Exception as e:` block (lines 168–169 region), add a server-side log call using the existing `logger` import.
- Return a generic error JSON (for example `"Failed to control Spotify playback"`) with an appropriate status code (500), instead of exposing `str(e)`.

No new imports or dependencies are required because `logger` is already imported from `config`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
