### PR TITLE
Potential fix for code scanning alert no. 17: Information exposure through an exception

### DIFF
--- a/spotify/routes.py
+++ b/spotify/routes.py
@@ -139,7 +139,8 @@ def register_spotify(app):
                 "next_track": next_track
             })
         except Exception as e:
-            return jsonify({"ok": False, "error": str(e)})
+            logger.exception("Error while fetching Spotify status for user_id=%s", user_id)
+            return jsonify({"ok": False, "error": "Internal server error"})
 
     @app.route("/api/spotify/control", methods=["POST"])
     def spotify_control():
@@ -166,7 +167,8 @@ def register_spotify(app):
             
             return jsonify({"ok": True})
         except Exception as e:
-            return jsonify({"ok": False, "error": str(e)})
+            logger.exception("Error while executing Spotify control action for user_id=%s", user_id)
+            return jsonify({"ok": False, "error": "Internal server error"})
 
     @app.route("/api/spotify/toggle", methods=["POST"])
     def spotify_toggle():


### PR DESCRIPTION
Potential fix for [https://github.com/SayGGGo/Tornado/security/code-scanning/17](https://github.com/SayGGGo/Tornado/security/code-scanning/17)

To fix this safely, do not return raw exception text to clients. Instead:
1. Log the exception server-side (with stack trace) using the existing `logger`.
2. Return a generic error message to the client.

Best targeted fix in `spotify/routes.py`:
- In `spotify_status` exception block (around lines 141–142), replace `str(e)` response with a generic message and add `logger.exception(...)`.
- In `spotify_control` exception block (around lines 168–169), do the same for consistency and to prevent a similar exposure.

No new imports are needed because `logger` is already imported from `config`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
