### PR TITLE
Potential fix for code scanning alert no. 23: Incomplete HTML attribute sanitization

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -568,7 +568,9 @@ function createFileContent(msg) {
 function openImageOverlay(src) {
     const overlay = document.createElement('div');
     overlay.className = 'image-overlay';
-    overlay.innerHTML = `<img src="${escHtml(src)}">`;
+    const img = document.createElement('img');
+    img.src = src || '';
+    overlay.appendChild(img);
     overlay.addEventListener('click', () => overlay.remove());
     document.addEventListener('keydown', function esc(e) { if (e.key === 'Escape') { overlay.remove(); document.removeEventListener('keydown', esc); } });
     document.body.appendChild(overlay);


### PR DESCRIPTION
Potential fix for [https://github.com/SayGGGo/Tornado/security/code-scanning/23](https://github.com/SayGGGo/Tornado/security/code-scanning/23)

The best fix is to avoid string-based HTML construction for this case and set DOM properties directly.  
For `openImageOverlay` in `static/js/chat.js`, replace:

- `overlay.innerHTML = \`<img src="${escHtml(src)}">\`;`

with safe DOM API usage:

- create an `img` element with `document.createElement('img')`
- assign `img.src = src || ''`
- append it to `overlay`

This preserves functionality (showing the image in the overlay) while removing attribute injection risk entirely, so no special attribute escaping is needed in this path. No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
