### PR TITLE
Potential fix for code scanning alert no. 27: Information exposure through an exception

### DIFF
--- a/admin/routes.py
+++ b/admin/routes.py
@@ -247,8 +247,8 @@ def register_admin(app):
             with open(env_path, "w", encoding="utf-8") as f:
                 f.write(content)
             return jsonify({"success": True})
-        except Exception as e:
-            return jsonify({"error": str(e)}), 500
+        except Exception:
+            return jsonify({"error": "Internal server error"}), 500
 
     @app.route(f"/{Config.ADMIN_SESSION_IND}/api/admins", methods=["GET"])
     @admin_required


### PR DESCRIPTION
Potential fix for [https://github.com/SayGGGo/Tornado/security/code-scanning/27](https://github.com/SayGGGo/Tornado/security/code-scanning/27)

The correct fix is to stop returning raw exception details to the client and instead return a generic error message. Keep functionality the same (still return HTTP 500 on failure), but avoid exposing internals.

Best single change in `admin/routes.py`:
- In `admin_save_env()` (`except Exception as e:` block around lines 250–251), replace `{"error": str(e)}` with a generic message like `{"error": "Internal server error"}`.
- Since `e` is no longer used, change `except Exception as e:` to `except Exception:`.

This removes the information leak while preserving behavior and response shape.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
