### PR TITLE
Potential fix for code scanning alert no. 26: Information exposure through an exception

### DIFF
--- a/admin/routes.py
+++ b/admin/routes.py
@@ -233,8 +233,8 @@ def register_admin(app):
             with open(env_path, "r", encoding="utf-8") as f:
                 content = f.read()
             return jsonify({"content": content, "exists": True})
-        except Exception as e:
-            return jsonify({"error": str(e)}), 500
+        except Exception:
+            return jsonify({"error": "Internal server error"}), 500
 
     @app.route(f"/{Config.ADMIN_SESSION_IND}/api/env", methods=["POST"])
     @admin_required
@@ -247,8 +247,8 @@ def register_admin(app):
             with open(env_path, "w", encoding="utf-8") as f:
                 f.write(content)
             return jsonify({"success": True})
-        except Exception as e:
-            return jsonify({"error": str(e)}), 500
+        except Exception:
+            return jsonify({"error": "Internal server error"}), 500
 
     @app.route(f"/{Config.ADMIN_SESSION_IND}/api/admins", methods=["GET"])
     @admin_required


### PR DESCRIPTION
Potential fix for [https://github.com/SayGGGo/Tornado/security/code-scanning/26](https://github.com/SayGGGo/Tornado/security/code-scanning/26)

To fix this, stop returning raw exception text to the client. Keep behavior and status codes the same, but replace `{"error": str(e)}` with a generic message such as `{"error": "Internal server error"}`. This avoids leaking implementation details while preserving API contract (`error` field + HTTP 500 on failure).

Best single fix in `admin/routes.py`:
- In `admin_get_env()` exception handler (around lines 236–237), replace response payload with a generic error string.
- In `admin_save_env()` exception handler (around lines 250–251), do the same.
- No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
